### PR TITLE
Add windows to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
     env:
       OS: ${{ matrix.os }}
@@ -51,6 +51,12 @@ jobs:
     - name: Build docs with sphinx
       run: |
         make -C docs/ html SPHINXOPTS="-W --keep-going -n"
+
+    - name: Install openssl
+      run: vcpkg integrate install; vcpkg install openssl:x64-windows
+      if: matrix.os == 'windows-latest'
+      env:
+        VCPKG_ROOT: 'C:\vcpkg'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install openssl
-      run: vcpkg integrate install; vcpkg install openssl:x64-windows
-      if: matrix.os == 'windows-latest'
-      env:
-        VCPKG_ROOT: 'C:\vcpkg'
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install openssl
+      run: vcpkg integrate install; vcpkg install openssl:x64-windows
+      if: matrix.os == 'windows-latest'
+      env:
+        VCPKG_ROOT: 'C:\vcpkg'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -51,12 +57,6 @@ jobs:
     - name: Build docs with sphinx
       run: |
         make -C docs/ html SPHINXOPTS="-W --keep-going -n"
-
-    - name: Install openssl
-      run: vcpkg integrate install; vcpkg install openssl:x64-windows
-      if: matrix.os == 'windows-latest'
-      env:
-        VCPKG_ROOT: 'C:\vcpkg'
 
     - name: Test with pytest
       run: |

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,7 +91,7 @@ class TemporaryCertificate:
                 public_exponent=65537, key_size=1024, backend=default_backend()
             )
 
-            key_file = stack.enter_context(tempfile.NamedTemporaryFile())
+            key_file = stack.enter_context(tempfile.NamedTemporaryFile(delete=False))
             key_file.write(
                 key.private_bytes(
                     encoding=serialization.Encoding.PEM,
@@ -118,7 +118,7 @@ class TemporaryCertificate:
                 .sign(key, hashes.SHA256(), default_backend())
             )
 
-            cert_file = stack.enter_context(tempfile.NamedTemporaryFile())
+            cert_file = stack.enter_context(tempfile.NamedTemporaryFile(delete=False))
             cert_file.write(cert.public_bytes(serialization.Encoding.PEM))
             cert_file.flush()
 


### PR DESCRIPTION
Add windows step to the build matrix.`aiorobinhood` unit tests use the cryptography module which depends on openssl. This is not configured properly on windows-latest so it must be handled separately.